### PR TITLE
Restrain Potential

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: all clean hooks
 
 all:
-	cd g2g; make;
+#	cd g2g; make;
 	cd lioamber; make;
 	cd liosolo; make;
 
 clean:
-	cd g2g; make clean;
+#	cd g2g; make clean;
 	cd lioamber; make clean;
 	cd liosolo; make clean;
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: all clean hooks
 
 all:
-#	cd g2g; make;
+	cd g2g; make;
 	cd lioamber; make;
 	cd liosolo; make;
 
 clean:
-#	cd g2g; make clean;
+	cd g2g; make clean;
 	cd lioamber; make clean;
 	cd liosolo; make clean;
 

--- a/lioamber/get_restrain_energy_forces.f90
+++ b/lioamber/get_restrain_energy_forces.f90
@@ -4,7 +4,8 @@
 !This routine calculate forces for a distance restrain
 !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-       use garcha_mod,only:natom,r, number_index, number_restr, restr_index, restr_pairs, restr_k, restr_r0, restr_w, verbose
+       use garcha_mod,only:natom,r, number_index, number_restr,         &
+       restr_index, restr_pairs, restr_k, restr_r0, restr_w, verbose
        implicit none
        integer :: i,j, k, l !auxiliar
        real*8, dimension(natom,natom) :: distx,disty,distz
@@ -96,7 +97,8 @@
 !This routine calculate energy for a distance restrain
 !
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
-       use garcha_mod,only:natom,r, number_index, number_restr, restr_index, restr_pairs, restr_k, restr_r0, restr_w
+       use garcha_mod,only:natom,r, number_index, number_restr,      &
+       restr_index, restr_pairs, restr_k, restr_r0, restr_w
        implicit none
        integer :: i,j,k,l !auxiliar
        real*8, dimension(natom,natom) :: distx,disty,distz

--- a/lioamber/liomods/garcha_mod.f
+++ b/lioamber/liomods/garcha_mod.f
@@ -151,6 +151,8 @@ c      parameter rmintsol=16.0D0
       INTEGER :: number_restr, number_index
       INTEGER, ALLOCATABLE, DIMENSION(:,:) :: restr_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) ::  restr_index
-      DOUBLE PRECISION, ALLOCATABLE, DIMENSION(:) :: restr_k, restr_w,
+      DOUBLE PRECISION, ALLOCATABLE, DIMENSION(:) :: restr_k,restr_w,
      > restr_r0
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%!
+      end module
+


### PR DESCRIPTION
Lio may add an extra potential term to Hamiltonian for penalty the distance between specified pairs of atoms. Details about implementaion and uses are in lio/docs/manual/